### PR TITLE
specs: Add L2 output submitter service

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'staging'
+      - 'feat/*'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'staging'
+      - 'feat/*'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/solidity-ci.yml
+++ b/.github/workflows/solidity-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'staging'
+      - 'feat/*'
   pull_request:
   workflow_dispatch:
 

--- a/packages/contracts/contracts/L1/L2OutputOracle.sol
+++ b/packages/contracts/contracts/L1/L2OutputOracle.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.8.10;
 
 /**
- * @title MockL2OutputOracle
+ * @title L2OutputOracle
  */
-contract MockL2OutputOracle {
+contract L2OutputOracle {
     uint256 public submissionInterval;
     uint256 public l2BlockTime;
     mapping(uint256 => bytes32) public l2Outputs;
@@ -13,7 +13,7 @@ contract MockL2OutputOracle {
     uint256 public startingBlockTimestamp;
 
     /**
-     * Initialize the MockL2OutputOracle contract.
+     * Initialize the L2OutputOracle contract.
      * @param _submissionInterval The desired interval in seconds at which
      *        checkpoints must be submitted.
      * @param _l2BlockTime The desired L2 inter-block time in seconds.

--- a/packages/contracts/contracts/L1/MockL2OutputOracle.sol
+++ b/packages/contracts/contracts/L1/MockL2OutputOracle.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.10;
  * @title MockL2OutputOracle
  */
 contract MockL2OutputOracle {
-    uint256 public submissionFrequency;
+    uint256 public submissionInterval;
     uint256 public l2BlockTime;
     mapping(uint256 => bytes32) public l2Outputs;
     uint256 public historicalTotalBlocks;
@@ -14,7 +14,7 @@ contract MockL2OutputOracle {
 
     /**
      * Initialize the MockL2OutputOracle contract.
-     * @param _submissionFrequency The desired interval in seconds at which
+     * @param _submissionInterval The desired interval in seconds at which
      *        checkpoints must be submitted.
      * @param _l2BlockTime The desired L2 inter-block time in seconds.
      * @param _genesisL2Output The initial L2 output of the L2 chain.
@@ -22,12 +22,12 @@ contract MockL2OutputOracle {
      *        initialization of the L2 chain.
      */
     constructor(
-        uint256 _submissionFrequency,
+        uint256 _submissionInterval,
         uint256 _l2BlockTime,
         bytes32 _genesisL2Output,
         uint256 _historicalTotalBlocks
     ) {
-        submissionFrequency = _submissionFrequency;
+        submissionInterval = _submissionInterval;
         l2BlockTime = _l2BlockTime;
         l2Outputs[block.timestamp] = _genesisL2Output; // solhint-disable not-rely-on-time
         historicalTotalBlocks = _historicalTotalBlocks;
@@ -56,7 +56,7 @@ contract MockL2OutputOracle {
      * checkpointed.
      */
     function nextTimestamp() public view returns (uint256) {
-        return latestBlockTimestamp + submissionFrequency;
+        return latestBlockTimestamp + submissionInterval;
     }
 
     /**

--- a/packages/contracts/contracts/L1/MockL2OutputOracle.sol
+++ b/packages/contracts/contracts/L1/MockL2OutputOracle.sol
@@ -46,6 +46,7 @@ contract MockL2OutputOracle {
         require(block.timestamp > _timestamp, "Cannot append L2 output in future");
         require(_l2Output != bytes32(0), "Cannot submit empty L2 output");
         require(_timestamp == nextTimestamp(), "Timestamp not equal to next expected timestamp");
+        // todo: add require statement to ensure a specific prev-hash exists on the current chain
         l2Outputs[_timestamp] = _l2Output;
         latestBlockTimestamp = _timestamp;
     }

--- a/specs/README.md
+++ b/specs/README.md
@@ -8,8 +8,9 @@ that maintains 1:1 compatibility with Ethereum.
 
 - [Glossary](glossary.md)
 - [Deposits](deposits.md)
+- [Withdrawals](withdrawals.md)
 - [Execution Engine](exec-engine.md)
-- [L2 output root Proposals](proposals.md)
+- [L2 Output Root Proposals](proposals.md)
 - [Rollup Node](rollup-node.md)
 
 ## Design Goals

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -37,6 +37,7 @@
   - [L2 Derivation Inputs](#l2-derivation-inputs)
   - [Payload Attributes](#payload-attributes)
   - [L1 Attributes Predeployed Contract](#l1-attributes-predeployed-contract)
+  - [L2 output](#l2-output)
 - [Execution Engine Concepts](#execution-engine-concepts)
   - [Execution Engine](#execution-engine)
 
@@ -366,6 +367,14 @@ A [predeployed contract][predeploy] on L2 that can be used to retrieve the L1 bl
 block number or a given block hash.
 
 cf. [L1 Attributes Predeployed Contract Specification](deposits.md#l1-attributes-predeployed-contract)
+
+## L2 output
+
+[l2-output]: glossary.md#l2-output
+
+A 32 byte value representing the current state of the L2 chain.
+
+cf. [Proposing L2 output commitments](proposals.md#l2-output-root-proposals-specification)
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -37,7 +37,7 @@
   - [L2 Derivation Inputs](#l2-derivation-inputs)
   - [Payload Attributes](#payload-attributes)
   - [L1 Attributes Predeployed Contract](#l1-attributes-predeployed-contract)
-  - [L2 output](#l2-output)
+  - [L2 Output Root](#l2-output-root)
 - [Execution Engine Concepts](#execution-engine-concepts)
   - [Execution Engine](#execution-engine)
 
@@ -368,7 +368,7 @@ block number or a given block hash.
 
 cf. [L1 Attributes Predeployed Contract Specification](deposits.md#l1-attributes-predeployed-contract)
 
-## L2 output
+## L2 Output Root
 
 [l2-output]: glossary.md#l2-output
 

--- a/specs/proposals.md
+++ b/specs/proposals.md
@@ -105,8 +105,8 @@ upgrades. This keeps the static merkle structure forwards-compatible.
 ## L2 Output Oracle Smart Contract
 
 L2 blocks are produced at a constant rate of `L2_BLOCK_TIME` (2 seconds).
-A new L2 output MUST be appended to the chain once per `SUBMISSION_INTERVAL` (1800 seconds). Note that this interval is based
-on L2 time. It is OK to have L2 outputs submitted at larger or small intervals.
+A new L2 output MUST be appended to the chain once per `SUBMISSION_INTERVAL` (1800 seconds). Note that this interval is\
+based on L2 time. It is OK to have L2 outputs submitted at larger or small intervals.
 
 The L2 Output Oracle contract implements the following interface:
 

--- a/specs/proposals.md
+++ b/specs/proposals.md
@@ -7,7 +7,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Constants](#constants)
+- [Definitions](#definitions)
+  - [Constants](#constants)
+  - [Types](#types)
 - [Proposing L2 Output Commitments](#proposing-l2-output-commitments)
 - [L2 Output Commitment Construction](#l2-output-commitment-construction)
 - [L2 Output Oracle Smart Contract](#l2-output-oracle-smart-contract)
@@ -34,7 +36,7 @@ are part of later specification milestones.
 
 | Name                   | Value | Unit    |
 | ---------------------- | ----- | ------- |
-| `SUBMISSION_FREQUENCY` | `100` | seconds |
+| `SUBMISSION_INTERVAL` | `1800` | seconds |
 | `L2_BLOCK_TIME`        | `2`   | seconds |
 
 ### Types
@@ -50,8 +52,8 @@ struct ForkSpec {
 
 ## Proposing L2 Output Commitments
 
-The proposer's role is to construct and submit output commitments on a configurable interval to a contract on  , which
-it does by running the [L2 output submitter](../l2os/) service (AKA L2OSS). This service periodically queries the rollup
+The proposer's role is to construct and submit output commitments on a configurable interval to a contract on , which
+it does by running the [L2 output submitter](../l2os/) (AKA L2OS). This service periodically queries the rollup
  node's [`optimism_outputAtBlock` rpc method](./rollup-node.md#l2-output-rpc-method) for the latest output root derived
  from the latest [finalized](rollup-node.md#finalization-guarantees) L1 block. The construction of this output root is
  described [below](#l2-output-commitment-construction).
@@ -103,8 +105,8 @@ upgrades. This keeps the static merkle structure forwards-compatible.
 ## L2 Output Oracle Smart Contract
 
 L2 blocks are produced at a constant rate of `L2_BLOCK_TIME` (2 seconds).
-A new L2 output MUST be appended to the chain once per `SUBMISSION_INTERVAL` (100 seconds). Note that interval is based on L2 time. It is OK to have L2 outputs
-submitted at larger or small intervals
+A new L2 output MUST be appended to the chain once per `SUBMISSION_INTERVAL` (1800 seconds). Note that this interval is based
+on L2 time. It is OK to have L2 outputs submitted at larger or small intervals.
 
 The L2 Output Oracle contract implements the following interface:
 
@@ -130,8 +132,7 @@ function appendL2Output(bytes32 _l2Output, uint256 _timestamp, ForkSpec _forkSpe
 
 
 /**
- * Computes the timestamp of the next L2 block that needs to be
- * checkpointed.
+ * Computes the timestamp of the next L2 block that needs to be checkpointed.
  */
 function nextTimestamp() public view returns (uint256) {
     return latestBlockTimestamp + submissionInterval;

--- a/specs/proposals.md
+++ b/specs/proposals.md
@@ -58,7 +58,7 @@ it does by running the [L2 output submitter](../l2os/) service (AKA L2OSS). This
 
 If there is no newly finalized output, the service continues querying until it receives one. It then submits this
 output, and the appropriate timestamp, to the [L2 Output Commitment](#l2-output-commitment-smart-contract) contract's
-`appendL2Output()` function. The timestamp MUST be the next multiple of the `SUBMISSION_FREQUENCY` value.
+`appendL2Output()` function. The timestamp MUST be the next multiple of the `SUBMISSION_INTERVAL` value.
 
 ## L2 Output Commitment Construction
 
@@ -103,7 +103,7 @@ upgrades. This keeps the static merkle structure forwards-compatible.
 ## L2 Output Oracle Smart Contract
 
 L2 blocks are produced at a constant rate of `L2_BLOCK_TIME` (2 seconds).
-A new L2 output MUST be appended to the chain once per `SUBMISSION_FREQUENCY` (100 seconds). Note that interval is based on L2 time. It is OK to have L2 outputs
+A new L2 output MUST be appended to the chain once per `SUBMISSION_INTERVAL` (100 seconds). Note that interval is based on L2 time. It is OK to have L2 outputs
 submitted at larger or small intervals
 
 The L2 Output Oracle contract implements the following interface:
@@ -134,7 +134,7 @@ function appendL2Output(bytes32 _l2Output, uint256 _timestamp, ForkSpec _forkSpe
  * checkpointed.
  */
 function nextTimestamp() public view returns (uint256) {
-    return latestBlockTimestamp + submissionFrequency;
+    return latestBlockTimestamp + submissionInterval;
 }
 
 /**

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -365,7 +365,7 @@ The input and return types here are as defined by the [engine API specs][engine-
 
 - method: `optimism_outputAtBlock`
 - params:
-  1. `QUANTITY` - L1 integer block number, or the strings `"safe"`, `"latest"`, or `"pending"`
+  1. `QUANTITY` - L2 integer block number, or the strings `"safe"`, `"latest"`, or `"pending"`
 - returns:
   2.`DATA` - The 32 byte output root
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -352,7 +352,7 @@ block forward each step, until there is an insufficient number of L1 blocks left
 
 ## L2 Output RPC method
 
-The Rollup node has its own RPC method, `optimism_output` which returns the
+The Rollup node has its own RPC method, `optimism_outputAtBlock` which returns the
 a 32 byte hash corresponding to the [SSZ] encoded [L2Output](./proposals.md#l2-output-commitment-construction).
 
 [SSZ]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
@@ -367,7 +367,7 @@ The input and return types here are as defined by the [engine API specs][engine-
 - params:
   1. `QUANTITY` - L2 integer block number, or the strings `"safe"`, `"latest"`, or `"pending"`
 - returns:
-  2.`DATA` - The 32 byte output root
+  1. `DATA` - The 32 byte output root
 
 # Handling L1 Re-Orgs
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -56,6 +56,8 @@ currently only concerned with the specification of the rollup driver.
     - [Engine API Error Handling](#engine-api-error-handling)
     - [Finalization Guarantees](#finalization-guarantees)
   - [Whole L2 Chain Derivation](#whole-l2-chain-derivation)
+  - [L2 Output RPC method](#l2-output-rpc-method)
+    - [Output Method API](#output-method-api)
 - [Handling L1 Re-Orgs](#handling-l1-re-orgs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -326,11 +328,12 @@ As stated earlier, an L2 block is considered *finalized* after a delay of `FINAL
 after the L1 block that generated it. This is a duration of approximately 7 days worth of L1 blocks. This is also known
 as the "fault proof window", as after this time the block can no longer be challenged by a fault proof.
 
-L1 Ethereum [reaches finality approximately every 12 minutes][l1-finality]. L2 blocks generated from finalized L1 blocks
+L1 Ethereum reaches [finality][l1-finality] approximately every [12.8 minutes][consensus-time-params]. L2 blocks generated from finalized L1 blocks
 are "safer" than most recent L2 blocks because they will never disappear from the chain's history because of a re-org.
 However, they can still be challenged by a fault proof until the end of the fault proof window.
 
-[l1-finality]: https://www.paradigm.xyz/2021/07/ethereum-reorgs-after-the-merge/
+[l1-finality]: https://www.paradigm.xyz/2021/07/ethereum-reorgs-after-the-merge
+[consensus-time-params]: https://github.com/ethereum/consensus-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#time-parameters
 
 > **TODO** the spec doesn't encode the notion of fault proof yet, revisit this (and include links) when it does
 
@@ -346,6 +349,25 @@ Then we iteratively apply the derivation process from the previous section by sh
 block forward each step, until there is an insufficient number of L1 blocks left for a complete sequencing window.
 
 > **TODO** specify genesis block
+
+## L2 Output RPC method
+
+The Rollup node has its own RPC method, `optimism_output` which returns the
+a 32 byte hash corresponding to the [SSZ] encoded [L2Output](./proposals.md#l2-output-commitment-construction).
+
+[SSZ]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
+
+### Output Method API
+
+The input and return types here are as defined by the [engine API specs][engine-structures]).
+
+[engine-structures]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#structures
+
+- method: `optimism_outputAtBlock`
+- params:
+  1. `QUANTITY` - L1 integer block number, or the strings `"safe"`, `"latest"`, or `"pending"`
+- returns:
+  2.`DATA` - The 32 byte output root
 
 # Handling L1 Re-Orgs
 

--- a/specs/rollup-node.md
+++ b/specs/rollup-node.md
@@ -328,9 +328,10 @@ As stated earlier, an L2 block is considered *finalized* after a delay of `FINAL
 after the L1 block that generated it. This is a duration of approximately 7 days worth of L1 blocks. This is also known
 as the "fault proof window", as after this time the block can no longer be challenged by a fault proof.
 
-L1 Ethereum reaches [finality][l1-finality] approximately every [12.8 minutes][consensus-time-params]. L2 blocks generated from finalized L1 blocks
-are "safer" than most recent L2 blocks because they will never disappear from the chain's history because of a re-org.
-However, they can still be challenged by a fault proof until the end of the fault proof window.
+L1 Ethereum reaches [finality][l1-finality] approximately every [12.8 minutes][consensus-time-params]. L2 blocks
+generated from finalized L1 blocksare "safer" than most recent L2 blocks because they will never disappear from the
+chain's history because of a re-org. However, they can still be challenged by a fault proof until the end of the fault
+proof window.
 
 [l1-finality]: https://www.paradigm.xyz/2021/07/ethereum-reorgs-after-the-merge
 [consensus-time-params]: https://github.com/ethereum/consensus-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#time-parameters


### PR DESCRIPTION
This PR adds the specifications for output submission, including the L2OutputOracle contract.